### PR TITLE
Add permalink toc feature

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,8 @@ extra_javascript:
 markdown_extensions:
   - extra
   - tables
+  - toc:
+      permalink: true
   - mdx_math
   - fenced_code
   - pymdownx.highlight:


### PR DESCRIPTION
This allows users to create a link via the headings to access a topic directly.

Pygments, required for #24, has a field to provide an URL to a language definition and I would like to directly link against the *Grammar of Soar productions* heading in [Syntax of Soar Programs](https://soar.eecs.umich.edu/soar_manual/03_SyntaxOfSoarPrograms/).